### PR TITLE
Cluster filter

### DIFF
--- a/static/myjs/map-functions.js
+++ b/static/myjs/map-functions.js
@@ -555,9 +555,9 @@ LF_MAP_APP = {
             onEachFeature: LF_MAP_APP.onEachFeature
         })
 
-        window.geoJson = geoJsonStructure._layers;
+        window.geojson = geoJsonStructure._layers;
 
-        window.main_map_layer = L.markerClusterGroup({disableClusteringAtZoom: 8}).addTo(window.map);
+        window.main_map_layer = L.markerClusterGroup({disableClusteringAtZoom: 12}).addTo(window.map);
         window.geojson_map_layer = L.geoJson(
             {
                 "type": "FeatureCollection",
@@ -576,9 +576,15 @@ LF_MAP_APP = {
     },
     filter_mapLayer: function() {
         var bounds = window.map.getBounds();
-        for (polygon in window.geoJson) {
-            if (bounds.contains(window.geoJson[polygon]._bounds.getNorthEast()) || bounds.contains(window.geoJson[polygon]._bounds.getNorthWest()) || bounds.contains(window.geoJson[polygon]._bounds.getSouthEast()) || bounds.contains(window.geoJson[polygon]._bounds.getSouthWest())) {
-                window.geojson_map_layer.addLayer(window.geoJson[polygon]);
+        for (polygon in window.geojson) {
+            if (bounds.contains(window.geojson[polygon].getLatLng())
+              || window.geojson[polygon]._bounds.contains(bounds)
+              || bounds.contains(window.geojson[polygon]._bounds.getNorthEast())
+              || bounds.contains(window.geojson[polygon]._bounds.getNorthWest())
+              || bounds.contains(window.geojson[polygon]._bounds.getSouthEast())
+              || bounds.contains(window.geojson[polygon]._bounds.getSouthWest())) {
+
+                window.geojson_map_layer.addLayer(window.geojson[polygon]);
             }
         }
     },

--- a/templates/scripts.html
+++ b/templates/scripts.html
@@ -3,8 +3,7 @@
     <link rel="stylesheet" href="https://openlayers.org/en/v4.6.4/css/ol.css" type="text/css">
     <link rel="stylesheet" href="static/css/nasa-roses.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-    <link rel="stylesheet" type="text/css" href="http://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/MarkerCluster.css" />
-    <link rel="stylesheet" type="text/css" href="http://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/MarkerCluster.Default.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.4.1/MarkerCluster.Default.css"/>
 </head>
 <!--jQuery-->
 <script src="//ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
@@ -24,8 +23,7 @@
 <script src="https://unpkg.com/leaflet@1.3.4/dist/leaflet.js"
    integrity="sha512-nMMmRyTVoLYqjP9hrbed9S+FzjZHW5gY1TWCHA5ckwXZBadntCNs8kEqAWdrb9O7rxbCaA4lKTIWjDXZxflOcA=="
    crossorigin=""></script>
-<script type='text/javascript' src='http://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/leaflet.markercluster.js'></script>
-
+<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.4.1/leaflet.markercluster.js"></script>
 
 <!--EXTERNAL JS-->
 <!--Needed to zoom to fusiontables!!!-->


### PR DESCRIPTION
- Added getLatLng function to polygons
- Uses leaflet.mastercluster.js version 1.4 to cluster polygons based on their lat/lng coordinates (note: can change disable zoom level)
- Custom filter function to render only polygons located in viewport using current moveend handler (ugly conditional statement, can shorten if willing to have edge polygons not rendered)
- Small changes related to integration